### PR TITLE
[WIP] Fixes related to types-publisher now supporting multiple minor versions in parallel

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@andrewbranch/definitely-not-slow",
-  "version": "1.4.8",
+  "version": "1.4.10",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -6193,7 +6193,7 @@
       "integrity": "sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c="
     },
     "types-publisher": {
-      "version": "github:microsoft/types-publisher#506c7847586c741f38dbb933041d8e421985cae3",
+      "version": "github:microsoft/types-publisher#5d6d4f4e3164040fffbf684b8a031c4231f8c636",
       "from": "github:microsoft/types-publisher#production",
       "requires": {
         "@octokit/rest": "^16.1.0",
@@ -6204,7 +6204,7 @@
         "azure-storage": "^2.0.0",
         "charm": "^1.0.2",
         "definitelytyped-header-parser": "3.8.2",
-        "dtslint": "^2.0.3",
+        "dtslint": "^2.0.5",
         "fs-extra": "4.0.0",
         "fstream": "^1.0.12",
         "longjohn": "^0.2.11",


### PR DESCRIPTION
This is barely a work-in-progress, tbh, but mostly wanted to make you aware of the types of issues that exist right now in the failing CI builds (e.g. [this one](https://dev.azure.com/definitelytyped/DefinitelyTyped/_build/results?buildId=35060&view=logs&j=275f1d19-1bd8-5591-b06b-07d489ea915a&t=40b1ee41-44d6-5bba-aa04-4b76a5c732e5)) due to [these changes](https://github.com/microsoft/types-publisher/pull/723).